### PR TITLE
fixing env

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -8,6 +8,7 @@ export const env = createEnv({
    */
   server: {
     NODE_ENV: z.enum(['development', 'test', 'production']),
+    AUTH_API_URL: z.string().url(),
   },
 
   /**
@@ -27,6 +28,7 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_AUTH_API_URL: process.env.NEXT_PUBLIC_AUTH_API,
+    AUTH_API_URL: process.env.AUTH_API_URL,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**


### PR DESCRIPTION
### TL;DR
Added `AUTH_API_URL` environment variable for server-side authentication API calls.

### What changed?
- Added `AUTH_API_URL` to the server environment configuration with URL validation
- Mapped `process.env.AUTH_API_URL` to the runtime environment

### Why make this change?
To separate client and server-side authentication API endpoints, improving security by keeping sensitive server-side API calls private and not exposed to the client.