### PR TITLE
changed http code to redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ export function middleware(req: NextRequest) {
   ];
 
   if (protectedRoutes.some((route) => pathname.startsWith(route)) && !user) {
-    return NextResponse.redirect(new URL("/login", req.url), 401);
+    return NextResponse.redirect(new URL("/login", req.url), 307);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
### TL;DR

Changed the HTTP status code for authentication redirects from 401 to 307.

### What changed?

Modified the middleware.ts file to use HTTP status code 307 (Temporary Redirect) instead of 401 (Unauthorized) when redirecting unauthenticated users to the login page.

### Why make this change?

Status code 307 is more appropriate for this redirect scenario as it maintains the original HTTP method during the redirect. The previous 401 status code indicates authentication failure but doesn't specify redirect behavior, which could cause inconsistent handling across different clients.