### PR TITLE
updated methods for requests

### DIFF
--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -21,7 +21,7 @@ export const checkAndRefreshToken = async () => {
     const user: UserStruct = JSON.parse(userCookie.toString()) as UserStruct;
 
     if (accessExpiresAt.getTime() - now.getTime() < REFRESH_THRESHOLD) {
-      const newTokens = await AuthService.refreshTokens(tokens.refresh_token);
+      const newTokens = await AuthService.refreshTokens();
 
       setCookie("tokens", JSON.stringify(newTokens), {
         path: "/",


### PR DESCRIPTION
### TL;DR

Refactored API endpoints to use RESTful patterns and moved auth header logic to a shared utility function.

### What changed?

- Moved `getAuthHeaders()` function from `requests.ts` to `lib.ts` to make it available across the application
- Refactored story-related API endpoints to follow RESTful conventions:
  - Changed endpoints from POST to GET for retrieval operations
  - Updated URL patterns to include resource IDs in the path (`/endpoint/{id}`) instead of in the request body
  - Removed unnecessary request bodies from GET and DELETE operations

### Why make this change?

This change improves API design by following RESTful conventions, making the API more intuitive and standard-compliant. Moving the authentication header logic to a shared utility function reduces code duplication and centralizes authentication handling, making the codebase more maintainable.