### PR TITLE
fixed fetchuserbyid body

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -272,7 +272,7 @@ export const AuthService = {
       {
         method: "POST",
         headers: getAuthHeaders(),
-        body: JSON.stringify({ id: ownerId.toHexString() }),
+        body: JSON.stringify({ user_id: ownerId.toHexString() }),
       },
     );
     return handleResponse<{ user: UserStruct }>(response).then((data) => ({


### PR DESCRIPTION
### TL;DR

Updated the request payload parameter name in the AuthService.

### What changed?

Changed the parameter name in the request body from `id` to `user_id` when making a POST request in the AuthService. The parameter still uses the same value (`ownerId.toHexString()`).

### Why make this change?

The backend API endpoint was updated to expect `user_id` instead of `id` in the request payload. This change aligns the frontend with the updated API contract to ensure proper communication between client and server.