### PR TITLE
fixed objectid related errors, changed it to string

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,6 @@
         "@tiptap/starter-kit": "^2.11.5",
         "@vercel/analytics": "^1.5.0",
         "babel-plugin-react-compiler": "^19.0.0-beta-bafa41b-20250307",
-        "bson-objectid": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cookies-next": "^5.1.0",
@@ -472,8 +471,6 @@
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "bson-objectid": ["bson-objectid@2.0.4", "", {}, "sha512-vgnKAUzcDoa+AeyYwXCoHyF2q6u/8H46dxu5JN+4/TZeq/Dlinn0K6GvxsCLb3LHUJl0m/TLiEK31kUwtgocMQ=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@tiptap/starter-kit": "^2.11.5",
     "@vercel/analytics": "^1.5.0",
     "babel-plugin-react-compiler": "^19.0.0-beta-bafa41b-20250307",
-    "bson-objectid": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cookies-next": "^5.1.0",

--- a/src/components/CollaboratedStories.tsx
+++ b/src/components/CollaboratedStories.tsx
@@ -14,14 +14,13 @@ import { formatDate } from "@/lib";
 import { AuthService, StoryService } from "@/lib/requests";
 import { type StoryDetails } from "@/types/storyInterfaces";
 import { useQuery } from "@tanstack/react-query";
-import type ObjectId from "bson-objectid";
 import { Calendar, Edit, Eye, Tag, User, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-const OwnerInfo = ({ ownerId }: { ownerId: ObjectId }) => {
+const OwnerInfo = ({ ownerId }: { ownerId: string }) => {
   const { data: ownerData, isLoading } = useQuery({
-    queryKey: ["user", ownerId.toHexString()],
+    queryKey: ["user", ownerId],
     queryFn: () => AuthService.getProfile(ownerId),
     staleTime: 1000 * 60 * 5,
   });
@@ -135,7 +134,7 @@ export default function CollaboratedStories() {
           <div className="space-y-6">
             {stories?.map((story) => (
               <div
-                key={story.id.toHexString()}
+                key={story.id}
                 className="flex flex-col md:flex-row gap-4 border-b pb-6 last:border-0"
               >
                 <div className="flex-1">

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -14,12 +14,11 @@ import { Label } from "@/components/ui/label";
 import { formatDate } from "@/lib";
 import { AuthService, StoryService } from "@/lib/requests";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import type ObjectId from "bson-objectid";
 import { BookOpen, Calendar, Tag, User } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
-const OwnerName = ({ ownerId }: { ownerId: ObjectId }) => {
+const OwnerName = ({ ownerId }: { ownerId: string }) => {
   const { data, isPending, error } = useQuery({
     queryKey: ["ownerName", ownerId],
     queryFn: () => AuthService.getUserName(ownerId),
@@ -55,10 +54,10 @@ export default function HomeContent() {
     queryFn: async ({ pageParam }) =>
       selectedGenres.length > 0
         ? StoryService.getByFilters({
-            genres: selectedGenres,
-            page: pageParam,
-            limit,
-          })
+          genres: selectedGenres,
+          page: pageParam,
+          limit,
+        })
         : StoryService.list(pageParam, limit),
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length === limit ? allPages.length + 1 : undefined,
@@ -74,10 +73,10 @@ export default function HomeContent() {
   const filteredStories = allStories.filter((story) =>
     searchQuery
       ? [story.title, story.description].some(
-          (text) =>
-            typeof text === "string" &&
-            text.toLowerCase().includes(searchQuery.toLowerCase()),
-        )
+        (text) =>
+          typeof text === "string" &&
+          text.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
       : true,
   );
 
@@ -187,7 +186,7 @@ export default function HomeContent() {
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 w-full">
                 {filteredStories.map((story) => (
                   <Card
-                    key={story.id.toHexString()}
+                    key={story.id}
                     className="flex flex-col h-fit w-full max-w-[350px] mx-auto hover:shadow-lg transition-shadow duration-300"
                   >
                     <CardHeader className="pb-2">
@@ -216,7 +215,7 @@ export default function HomeContent() {
                       <Button
                         className="w-full cursor-pointer"
                         onClick={() =>
-                          router.push(`/story/${story.id.toHexString()}`)
+                          router.push(`/story/${story.id}`)
                         }
                       >
                         <BookOpen className="mr-2 h-4 w-4" /> Read Now

--- a/src/components/StoryEditor.tsx
+++ b/src/components/StoryEditor.tsx
@@ -21,7 +21,6 @@ import TextAlign from "@tiptap/extension-text-align";
 import Underline from "@tiptap/extension-underline";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import ObjectId from "bson-objectid";
 import { createLowlight } from "lowlight";
 import {
   AlignCenter,
@@ -54,12 +53,11 @@ export default function StoryEditor() {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState("");
-  const [userId, setUserId] = useState<ObjectId | null>(new ObjectId());
+  const [userId, setUserId] = useState<string | null>("");
   useEffect(() => {
     setUserId(getUserId());
   }, []);
   const story_id = params?.story_id as string;
-  const storyId = new ObjectId(story_id);
   const lowlight = createLowlight();
   const {
     data: story,
@@ -67,7 +65,7 @@ export default function StoryEditor() {
     error: storyError,
   } = useQuery({
     queryKey: ["story", story_id],
-    queryFn: () => StoryService.getDetails(storyId),
+    queryFn: () => StoryService.getDetails(story_id),
     enabled: !!story_id,
   });
 
@@ -77,13 +75,13 @@ export default function StoryEditor() {
     error: contentError,
   } = useQuery({
     queryKey: ["content", story_id],
-    queryFn: () => StoryService.getContent(storyId),
+    queryFn: () => StoryService.getContent(story_id),
     enabled: !!story_id,
   });
 
   const { data: collaborators } = useQuery({
     queryKey: ["collaborators", story_id],
-    queryFn: () => StoryService.getCollaborators(storyId),
+    queryFn: () => StoryService.getCollaborators(story_id),
     enabled: !!story_id,
   });
 
@@ -141,7 +139,7 @@ export default function StoryEditor() {
     story &&
     userId &&
     (story.owner_id === userId ||
-      collaborators?.includes(userId.toHexString()));
+      collaborators?.includes(userId));
 
   if (!story_id)
     return (

--- a/src/components/UserStories.tsx
+++ b/src/components/UserStories.tsx
@@ -12,7 +12,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate } from "@/lib";
 import { StoryService } from "@/lib/requests";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type ObjectId from "bson-objectid";
 import { BookOpen, Calendar, Edit, Tag, Trash2, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -29,8 +28,8 @@ export default function UserStories() {
     queryFn: () => StoryService.getUserStories(currentPage, limit),
   });
 
-  const mutation = useMutation<void, Error, ObjectId>({
-    mutationFn: (storyId: ObjectId) => StoryService.delete(storyId),
+  const mutation = useMutation<void, Error, string>({
+    mutationFn: (storyId: string) => StoryService.delete(storyId),
     onSuccess: async () => {
       setErrorMessage(null);
       try {
@@ -50,7 +49,7 @@ export default function UserStories() {
 
   const stories = data ?? [];
 
-  const handleDeleteStory = (storyId: ObjectId) => {
+  const handleDeleteStory = (storyId: string) => {
     mutation.mutate(storyId);
   };
 
@@ -151,7 +150,7 @@ export default function UserStories() {
           <div className="space-y-6">
             {stories.map((story) => (
               <div
-                key={story.id.toHexString()}
+                key={story.id}
                 className="flex flex-col md:flex-row gap-4 border-b pb-6 last:border-0"
               >
                 <div className="flex-1">
@@ -184,7 +183,7 @@ export default function UserStories() {
                       className="cursor-pointer"
                       size="sm"
                       onClick={() =>
-                        router.push(`/story/${story.id.toHexString()}`)
+                        router.push(`/story/${story.id}`)
                       }
                     >
                       <Edit className="h-4 w-4 mr-1" />

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,3 @@
-import ObjectId from "bson-objectid";
 import { getCookie } from "cookies-next";
 import { type Tokens, type UserStruct } from "@/types/authInterfaces";
 
@@ -86,7 +85,7 @@ export const formatDate = (dateInput: string | Date | null | undefined): string 
   }
 };
 
-export const getUserId = (): ObjectId | null => {
+export const getUserId = (): string | null => {
   const result = parseCookie<UserStruct>("user");
 
   if (!result.success) {
@@ -99,13 +98,13 @@ export const getUserId = (): ObjectId | null => {
 
   const userId = result.data.id?.trim();
 
-  if (!userId || !ObjectId.isValid(userId)) {
+  if (!userId && userId.trim().length === 0) {
     console.error("Invalid or missing user ID in cookie");
     return null;
   }
 
   try {
-    return new ObjectId(userId);
+    return userId;
   } catch (error) {
     console.error(
       "ObjectId creation failed:",

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -9,7 +9,6 @@ import {
 import { type loginSchema, type registerSchema } from "@/types/authSchemas";
 import type * as storyResponses from "@/types/storyInterfaces";
 import { type storySchema } from "@/types/storySchemas";
-import type ObjectId from "bson-objectid";
 import { type z } from "zod";
 
 const API_CONFIG = {
@@ -77,9 +76,9 @@ export const StoryService = {
     );
   },
 
-  async getDetails(storyId: ObjectId): Promise<storyResponses.StoryDetails> {
+  async getDetails(storyId: string): Promise<storyResponses.StoryDetails> {
     const response = await fetch(
-      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.STORY_DETAILS}/${storyId.toHexString()}`,
+      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.STORY_DETAILS}/${storyId}`,
       {
         method: "GET",
         headers: getAuthHeaders(),
@@ -107,9 +106,9 @@ export const StoryService = {
     );
   },
 
-  async getContent(storyId: ObjectId): Promise<storyResponses.StoryContent> {
+  async getContent(storyId: string): Promise<storyResponses.StoryContent> {
     const response = await fetch(
-      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.STORY_CONTENT}/${storyId.toHexString()}`,
+      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.STORY_CONTENT}/${storyId}`,
       {
         method: "GET",
         headers: { "Content-Type": "application/json" },
@@ -120,9 +119,9 @@ export const StoryService = {
     ).then((data) => data.content);
   },
 
-  async delete(storyId: ObjectId): Promise<void> {
+  async delete(storyId: string): Promise<void> {
     const response = await fetch(
-      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.DELETE_STORY}/${storyId.toHexString()}`,
+      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.DELETE_STORY}/${storyId}`,
       {
         method: "DELETE",
         headers: getAuthHeaders(),
@@ -131,9 +130,9 @@ export const StoryService = {
     await handleResponse<{ message: string }>(response);
   },
 
-  async getCollaborators(storyId: ObjectId): Promise<string[]> {
+  async getCollaborators(storyId: string): Promise<string[]> {
     const response = await fetch(
-      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.COLLABORATORS}/${storyId.toHexString()}`,
+      `${API_CONFIG.STORY.BASE_URL}${API_CONFIG.STORY.ENDPOINTS.COLLABORATORS}/${storyId}`,
       {
         method: "GET",
         headers: { "Content-Type": "application/json" },
@@ -236,14 +235,14 @@ export const AuthService = {
   },
 
   async getProfile(
-    userId: ObjectId,
+    userId: string,
   ): Promise<{ first_name: string; last_name: string }> {
     const response = await fetch(
       `${API_CONFIG.AUTH.BASE_URL}${API_CONFIG.AUTH.ENDPOINTS.FETCH_USER}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ user_id: userId.toHexString() }),
+        body: JSON.stringify({ user_id: userId }),
       },
     );
     return handleResponse<UserStruct>(response).then((user) => ({
@@ -265,14 +264,14 @@ export const AuthService = {
   },
 
   async getUserName(
-    ownerId: ObjectId,
+    ownerId: string,
   ): Promise<{ first_name: string; last_name: string }> {
     const response = await fetch(
       `${API_CONFIG.AUTH.BASE_URL}${API_CONFIG.AUTH.ENDPOINTS.FETCH_USER_BY_ID}`,
       {
         method: "POST",
         headers: getAuthHeaders(),
-        body: JSON.stringify({ user_id: ownerId.toHexString() }),
+        body: JSON.stringify({ user_id: ownerId }),
       },
     );
     return handleResponse<{ user: UserStruct }>(response).then((data) => ({

--- a/src/types/storyInterfaces.ts
+++ b/src/types/storyInterfaces.ts
@@ -1,20 +1,18 @@
-import type ObjectId from "bson-objectid";
-
 export interface StoryDetails {
-  id: ObjectId;
+  id: string;
   title: string;
   description: string;
   genre: string;
-  owner_id: ObjectId;
-  collaborators?: ObjectId[];
+  owner_id: string;
+  collaborators?: string[];
   created_at: string;
   updated_at: string;
-  forkedFrom?: ObjectId | null;
+  forkedFrom?: string | null;
 }
 
 export interface StoryContent {
-  id: ObjectId;
-  story_id: ObjectId;
+  id: string;
+  story_id: string;
   content: string;
 }
 


### PR DESCRIPTION
### TL;DR

Removed the `bson-objectid` dependency and replaced ObjectId types with string types throughout the application.

### What changed?

- Removed the `bson-objectid` dependency from package.json and bun.lock
- Changed all ObjectId types to string types in components and service functions
- Updated function parameters and return types to use string IDs instead of ObjectId instances
- Removed ObjectId validation and conversion logic in getUserId()
- Updated API calls to use string IDs directly instead of calling toHexString()

### Why make this change?

This change simplifies the ID handling by using native string types instead of the ObjectId class. This reduces dependencies and potential points of failure while maintaining the same functionality. The backend likely already handles string IDs properly, making the ObjectId conversion unnecessary in the frontend application.