### PR TITLE
tryna fix jwt middlewares

### DIFF
--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -14,9 +14,9 @@ const FallBack = () => (
       <h1 className="text-4xl font-bold tracking-tight">
         <Skeleton className="w-1/2 mx-auto" />
       </h1>
-      <p className="mt-4 text-lg max-w-2xl mx-auto">
+      <div className="mt-4 text-lg max-w-2xl mx-auto">
         <Skeleton className="w-3/4 mx-auto" />
-      </p>
+      </div>
     </section>
 
     <div className="flex flex-col md:flex-row max-w-7xl mx-auto w-full px-4 py-8">

--- a/src/components/ProfileInfo.tsx
+++ b/src/components/ProfileInfo.tsx
@@ -20,7 +20,7 @@ import { AuthService } from "@/lib/requests";
 import { type UserStruct } from "@/types/authInterfaces";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteCookie, getCookie, setCookie } from "cookies-next/client";
-import { Edit2, Save } from "lucide-react";
+import { Edit2, Save, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -104,6 +104,10 @@ export default function ProfileInfo() {
     );
   }
 
+  function handleDeleteUser(): void {
+    throw new Error("Function not implemented.");
+  }
+
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -114,24 +118,35 @@ export default function ProfileInfo() {
               View and manage your personal information
             </CardDescription>
           </div>
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            size="sm"
-            onClick={() => setIsEditing(!isEditing)}
-          >
-            {isEditing ? (
-              <>
-                <Edit2 className="h-4 w-4 mr-2" />
-                Cancel
-              </>
-            ) : (
-              <>
-                <Edit2 className="h-4 w-4 mr-2" />
-                Edit Profile
-              </>
-            )}
-          </Button>
+          <div className="flex space-x-2">
+            <Button
+              className="cursor-pointer"
+              variant="outline"
+              size="sm"
+              onClick={() => setIsEditing(!isEditing)}
+            >
+              {isEditing ? (
+                <>
+                  <Edit2 className="h-4 w-4 mr-2" />
+                  Cancel
+                </>
+              ) : (
+                <>
+                  <Edit2 className="h-4 w-4 mr-2" />
+                  Edit Profile
+                </>
+              )}
+            </Button>
+            <Button
+              className="cursor-pointer"
+              variant="destructive"
+              size="sm"
+              onClick={() => handleDeleteUser()}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Delete Account
+            </Button>
+          </div>
         </div>
       </CardHeader>
       <CardContent>
@@ -240,6 +255,6 @@ export default function ProfileInfo() {
           </form>
         </Form>
       </CardContent>
-    </Card>
+    </Card >
   );
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -42,8 +42,7 @@ export const getRefreshToken = (): string | null => getToken("refresh_token");
 
 export const getAuthHeaders = (): HeadersInit => {
   const token = getAccessToken();
-  if (!token) throw new Error("Authorization token not found in cookies");
-
+  if (!token) window.location.href = "/login";
   return {
     "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
@@ -52,7 +51,7 @@ export const getAuthHeaders = (): HeadersInit => {
 
 export const getRefreshHeaders = (): HeadersInit => {
   const token = getRefreshToken();
-  if (!token) throw new Error("Refresh token not found in cookies");
+  if (!token) window.location.href = "/login";
 
   return {
     "Content-Type": "application/json",

--- a/src/types/authInterfaces.ts
+++ b/src/types/authInterfaces.ts
@@ -16,6 +16,18 @@ export interface Tokens {
   refresh_expires_at: string;
 }
 
+export interface AccessToken {
+  access_token: string;
+  access_created_at: string;
+  access_expires_at: string;
+}
+
+export interface RefreshToken {
+  refresh_token: string;
+  refresh_created_at: string;
+  refresh_expires_at: string;
+}
+
 export interface RegisterResponse {
   message: string;
   user: UserStruct;


### PR DESCRIPTION
### TL;DR

Added a "Delete Account" button to the profile page and improved authentication error handling.

### What changed?

- Changed a `<p>` tag to a `<div>` in the browse page fallback component for better semantic structure
- Added a "Delete Account" button with a destructive variant next to the "Edit Profile" button
- Added a placeholder `handleDeleteUser()` function that currently throws an error
- Improved authentication error handling by redirecting to the login page instead of throwing errors when tokens are missing
- Added new interfaces for `AccessToken` and `RefreshToken` in the auth types

### Why make this change?

This change improves the user experience by providing a way for users to delete their accounts directly from the profile page. It also enhances error handling by gracefully redirecting users to the login page when authentication tokens are missing rather than throwing errors, creating a smoother authentication flow.