### PR TITLE
dependabot not updating bun.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "bun"
     directory: "/"


### PR DESCRIPTION
### TL;DR

Enable beta ecosystems in Dependabot configuration.

### What changed?

Added `enable-beta-ecosystems: true` to the Dependabot configuration file to allow Dependabot to work with ecosystems that are still in beta support.

### Why make this change?

Bun package ecosystem support in Dependabot is currently in beta. Enabling beta ecosystems is required to ensure Dependabot can properly manage dependencies for the Bun package ecosystem specified in the configuration.