### PR TITLE
fixed weird unintentional redirect

### DIFF
--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -4,7 +4,7 @@ import { parseCookie } from "@/lib";
 import { AuthService } from "@/lib/requests";
 import type { AccessToken, UserStruct } from "@/types/authInterfaces";
 import { deleteCookie, setCookie } from "cookies-next/client";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export const REFRESH_THRESHOLD = 5 * 60 * 1000;
@@ -100,8 +100,10 @@ export const checkAndRefreshToken = async () => {
 
 export const useTokenRefresh = () => {
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
+    const isAuthPage = pathname === "/login" || pathname === "/register";
     let timeoutId: NodeJS.Timeout;
 
     const checkAuthState = async () => {
@@ -109,7 +111,9 @@ export const useTokenRefresh = () => {
         const result = await checkAndRefreshToken();
 
         if (!result.success) {
-          router.push("/");
+          if (!isAuthPage) {
+            router.push("/");
+          }
           return;
         }
 
@@ -146,5 +150,5 @@ export const useTokenRefresh = () => {
       clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [router]);
+  }, [router, pathname]);
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,7 +3,7 @@ import type {
   RefreshToken,
   UserStruct,
 } from "@/types/authInterfaces";
-import { getCookie } from "cookies-next";
+import { getCookie } from "cookies-next/client";
 
 type SafeParseResult<T> =
   | { success: true; data: T }


### PR DESCRIPTION
### TL;DR

Fixed token refresh logic to prevent redirect loops on authentication pages.

### What changed?

- Added `usePathname` hook to detect when a user is on authentication pages (`/login` or `/register`)
- Modified the token refresh logic to only redirect to home page when token refresh fails and the user is not already on an authentication page
- Updated the import for `getCookie` to use the client version from `cookies-next/client`
- Added pathname dependency to the useEffect dependency array

### Why make this change?

Previously, the token refresh mechanism would redirect users to the home page whenever token refresh failed, even if they were already on authentication pages. This created redirect loops and prevented users from accessing the login and registration pages when not authenticated. This change ensures that users can access authentication pages without being redirected away.