### PR TITLE
converted as many requests as possible to type-fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@t3-oss/env-nextjs": "^0.12.0",
         "@tanstack/react-query": "^5.67.2",
-        "@thatguyjamal/type-fetch": "^0.1.5",
+        "@thatguyjamal/type-fetch": "^0.2.0",
         "@tiptap/extension-code-block-lowlight": "^2.11.5",
         "@tiptap/extension-highlight": "^2.11.5",
         "@tiptap/extension-horizontal-rule": "^2.11.5",
@@ -307,7 +307,7 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.69.0", "", { "dependencies": { "@tanstack/query-core": "5.69.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA=="],
 
-    "@thatguyjamal/type-fetch": ["@thatguyjamal/type-fetch@0.1.5", "", {}, "sha512-MEAbKAIiKGfGH9tvc8HIjn7rVWI5CphX+dWt16a2OCJW6UwIUFTHsebU5NVliSvXP+Uz2fkHDl8q5sKmyPBwDw=="],
+    "@thatguyjamal/type-fetch": ["@thatguyjamal/type-fetch@0.2.0", "", {}, "sha512-bNjJokGmNXxpvtoKEfA1WlrnfT2XFfLb+aY/48nw7kkXzfU4uXvNcEf8uHybBt5nD41O9pxFGjlNBGcPG6BiKw=="],
 
     "@tiptap/core": ["@tiptap/core@2.11.5", "", { "peerDependencies": { "@tiptap/pm": "^2.7.0" } }, "sha512-jb0KTdUJaJY53JaN7ooY3XAxHQNoMYti/H6ANo707PsLXVeEqJ9o8+eBup1JU5CuwzrgnDc2dECt2WIGX9f8Jw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@t3-oss/env-nextjs": "^0.12.0",
     "@tanstack/react-query": "^5.67.2",
-    "@thatguyjamal/type-fetch": "^0.1.5",
+    "@thatguyjamal/type-fetch": "^0.2.0",
     "@tiptap/extension-code-block-lowlight": "^2.11.5",
     "@tiptap/extension-highlight": "^2.11.5",
     "@tiptap/extension-horizontal-rule": "^2.11.5",

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -49,7 +49,6 @@ export const getAuthHeaders = (): HeadersInit => {
     return {};
   }
   const headers = {
-    "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
   };
   return headers;
@@ -61,7 +60,6 @@ export const getRefreshHeaders = (): HeadersInit => {
     return {};
   }
   const headers = {
-    "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
   };
   return headers;


### PR DESCRIPTION
### TL;DR

Upgraded `@thatguyjamal/type-fetch` to v0.2.0 and refactored API requests to use the TFetchClient.

### What changed?

- Updated `@thatguyjamal/type-fetch` from v0.1.5 to v0.2.0 in both package.json and bun.lock
- Implemented TFetchClient with retry configuration (2 retries with 1000ms delay)
- Refactored all API requests in StoryService and AuthService to use the new TFetchClient
- Removed redundant "Content-Type" headers from auth header functions
- Simplified error handling with the new client's built-in error management
- Improved response type handling throughout the codebase

### Why make this change?

The new version of type-fetch provides better type safety, built-in retry functionality, and a more consistent API for making HTTP requests. This refactoring simplifies our code by removing the manual response handling logic and leveraging the library's built-in error management, making the codebase more maintainable and robust against network failures.