### PR TITLE
fixed wrong url

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://storysync.vercel.app/sitemap.xml
+Sitemap: https://storysync-delta.vercel.app/sitemap.xml
 
 # Crawl-delay to prevent overwhelming the server
 Crawl-delay: 10

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://storysync.vercel.app"),
+  metadataBase: new URL("https://storysync-delta.vercel.app"),
   title: {
     default: "StorySync - Collaborative Storytelling Platform",
     template: "StorySync | %s",
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://storysync.vercel.app",
+    url: "https://storysync-delta.vercel.app",
     title: "StorySync - Collaborative Storytelling Platform",
     description:
       "StorySync is a collaborative platform where writers can create, share, and co-author stories together.",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,31 +3,31 @@ import { type MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://storysync.vercel.app",
+      url: "https://storysync-delta.vercel.app",
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: "https://storysync.vercel.app/register",
+      url: "https://storysync-delta.vercel.app/register",
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://storysync.vercel.app/login",
+      url: "https://storysync-delta.vercel.app/login",
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://storysync.vercel.app/terms-of-service",
+      url: "https://storysync-delta.vercel.app/terms-of-service",
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.5,
     },
     {
-      url: "https://storysync.vercel.app/privacy-policy",
+      url: "https://storysync-delta.vercel.app/privacy-policy",
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.5,


### PR DESCRIPTION
### TL;DR

Updated all site URLs from `storysync.vercel.app` to `storysync-delta.vercel.app`

### What changed?

- Modified the Sitemap URL in `robots.txt`
- Updated the `metadataBase` URL in the layout component
- Changed the OpenGraph URL in metadata
- Updated all URLs in the sitemap generator function

### Why make this change?

This change updates the deployment domain from the main production URL to the delta preview environment. This ensures proper SEO configuration and sitemap functionality for the preview deployment, allowing for testing before merging to the main production environment.