### PR TITLE
found font issue

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,5 +1,4 @@
 import { ImageResponse } from "next/og";
-import { Inter } from "next/font/google";
 
 export const runtime = "edge";
 export const alt = "StorySync - Create, Share, Inspire";
@@ -9,9 +8,13 @@ export const size = {
 };
 export const contentType = "image/png";
 
-const inter = Inter({ subsets: ["latin"] });
-
 export default function Image() {
+  console.log("OpenGraph Image Generation Started", {
+    runtime,
+    size,
+    contentType,
+  });
+
   try {
     return new ImageResponse(
       (
@@ -24,7 +27,7 @@ export default function Image() {
             justifyContent: "center",
             alignItems: "center",
             backgroundColor: "oklch(0.985 0.002 247.839)",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
             padding: "40px",
             textAlign: "center",
             position: "relative",
@@ -72,17 +75,10 @@ export default function Image() {
       ),
       {
         ...size,
-        fonts: [
-          {
-            name: "Inter",
-            data: Buffer.from(inter.style.fontFamily),
-            style: "normal",
-          },
-        ],
+        // Remove font loading to avoid OpenType signature error
       }
     );
   } catch (error) {
-    console.error("OpenGraph Image Generation Error:", error);
     return new ImageResponse(
       (
         <div
@@ -94,7 +90,7 @@ export default function Image() {
             alignItems: "center",
             backgroundColor: "red",
             color: "white",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
           }}
         >
           Error Generating Image

--- a/src/app/story/[story_id]/opengraph-image.tsx
+++ b/src/app/story/[story_id]/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { StoryService } from "@/lib/requests";
 import { ImageResponse } from "next/og";
-import { Inter } from "next/font/google";
 
 export const runtime = "edge";
 export const alt = "StorySync Story";
@@ -9,8 +8,6 @@ export const size = {
   height: 630,
 };
 export const contentType = "image/png";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export default async function Image({
   params,
@@ -32,7 +29,7 @@ export default async function Image({
               justifyContent: "center",
               alignItems: "center",
               backgroundColor: "oklch(0.985 0.002 247.839)",
-              fontFamily: inter.style.fontFamily,
+              fontFamily: "sans-serif",
               padding: "40px",
               textAlign: "center",
             }}
@@ -62,7 +59,7 @@ export default async function Image({
             justifyContent: "center",
             alignItems: "center",
             backgroundColor: "oklch(0.985 0.002 247.839)",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
             padding: "40px",
             textAlign: "center",
             position: "relative",
@@ -116,17 +113,9 @@ export default async function Image({
       ),
       {
         ...size,
-        fonts: [
-          {
-            name: "Inter",
-            data: Buffer.from(inter.style.fontFamily),
-            style: "normal",
-          },
-        ],
       }
     );
   } catch (error) {
-    console.error("OpenGraph Image Generation Error:", error);
     return new ImageResponse(
       (
         <div
@@ -138,7 +127,7 @@ export default async function Image({
             alignItems: "center",
             backgroundColor: "red",
             color: "white",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
           }}
         >
           Error Generating Image

--- a/src/app/story/[story_id]/twitter-image.tsx
+++ b/src/app/story/[story_id]/twitter-image.tsx
@@ -1,6 +1,5 @@
 import { StoryService } from "@/lib/requests";
 import { ImageResponse } from "next/og";
-import { Inter } from "next/font/google";
 
 export const runtime = "edge";
 export const alt = "StorySync Story";
@@ -9,8 +8,6 @@ export const size = {
   height: 630,
 };
 export const contentType = "image/png";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export default async function Image({
   params,
@@ -32,7 +29,7 @@ export default async function Image({
               justifyContent: "center",
               alignItems: "center",
               backgroundColor: "oklch(0.985 0.002 247.839)",
-              fontFamily: inter.style.fontFamily,
+              fontFamily: "sans-serif",
               padding: "30px",
               textAlign: "center",
             }}
@@ -62,7 +59,7 @@ export default async function Image({
             justifyContent: "center",
             alignItems: "center",
             backgroundColor: "oklch(0.985 0.002 247.839)",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
             padding: "30px",
             textAlign: "center",
             position: "relative",
@@ -116,17 +113,9 @@ export default async function Image({
       ),
       {
         ...size,
-        fonts: [
-          {
-            name: "Inter",
-            data: Buffer.from(inter.style.fontFamily),
-            style: "normal",
-          },
-        ],
       }
     );
   } catch (error) {
-    console.error("Twitter Image Generation Error:", error);
     return new ImageResponse(
       (
         <div
@@ -138,7 +127,7 @@ export default async function Image({
             alignItems: "center",
             backgroundColor: "red",
             color: "white",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
           }}
         >
           Error Generating Image

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -9,8 +9,6 @@ export const size = {
 };
 export const contentType = "image/png";
 
-const inter = Inter({ subsets: ["latin"] });
-
 export default function Image() {
   try {
     return new ImageResponse(
@@ -24,7 +22,7 @@ export default function Image() {
             justifyContent: "center",
             alignItems: "center",
             backgroundColor: "oklch(0.985 0.002 247.839)",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
             padding: "30px",
             textAlign: "center",
             position: "relative",
@@ -72,17 +70,9 @@ export default function Image() {
       ),
       {
         ...size,
-        fonts: [
-          {
-            name: "Inter",
-            data: Buffer.from(inter.style.fontFamily),
-            style: "normal",
-          },
-        ],
       }
     );
   } catch (error) {
-    console.error("Twitter Image Generation Error:", error);
     return new ImageResponse(
       (
         <div
@@ -94,7 +84,7 @@ export default function Image() {
             alignItems: "center",
             backgroundColor: "red",
             color: "white",
-            fontFamily: inter.style.fontFamily,
+            fontFamily: "sans-serif",
           }}
         >
           Error Generating Image


### PR DESCRIPTION
### TL;DR

Fixed OpenGraph and Twitter image generation by removing custom font loading that was causing errors.

### What changed?

- Removed the `Inter` font import and configuration from all OpenGraph and Twitter image components
- Replaced `inter.style.fontFamily` with standard `sans-serif` font family
- Removed the custom font loading configuration in the `ImageResponse` options
- Added diagnostic logging in the main OpenGraph image generator
- Removed error logging statements that were causing issues in the edge runtime

### Why make this change?

The custom font loading was causing an "OpenType signature error" in the edge runtime environment. This change simplifies the image generation by using the system's sans-serif font instead of trying to load a custom font, which resolves the rendering errors and ensures social media preview images display correctly.