### PR TITLE
set age to 18

### DIFF
--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -140,9 +140,9 @@ export function PrivacyPolicy() {
     },
     {
       title: "Children's Privacy",
-      content: "Our Service does not address anyone under the age of 13.",
+      content: "Our Service does not address anyone under the age of 18.",
       list: [
-        "We do not knowingly collect personally identifiable information from anyone under the age of 13",
+        "We do not knowingly collect personally identifiable information from anyone under the age of 18",
         "If You are a parent or guardian and You are aware that Your child has provided Us with Personal Data, please contact Us",
       ],
     },


### PR DESCRIPTION
### TL;DR

Updated the minimum age requirement in the Privacy Policy from 13 to 18 years.

### What changed?

Modified the "Children's Privacy" section in the Privacy Policy component to change all references to the minimum age from 13 to 18 years old. This affects both the main content statement and the first bullet point in the list.

### Why make this change?

To align our privacy policy with stricter age requirements, ensuring compliance with regulations that require users to be at least 18 years old to use our service.