### PR TITLE
removed geist

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cookies-next": "^5.1.0",
-        "geist": "^1.3.1",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.487.0",
         "next": "^15.2.4",
@@ -823,8 +822,6 @@
     "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
-
-    "geist": ["geist@1.3.1", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-Q4gC1pBVPN+D579pBaz0TRRnGA4p9UK6elDY/xizXdFk/g4EKR5g0I+4p/Kj6gM0SajDBZ/0FvDV9ey9ud7BWw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cookies-next": "^5.1.0",
-    "geist": "^1.3.1",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.487.0",
     "next": "^15.2.4",


### PR DESCRIPTION
### TL;DR

Removed the `geist` package dependency from the project.

### What changed?

- Removed the `geist` package from `package.json` dependencies
- Updated the `bun.lock` file to reflect the removal of the `geist` package

### Why make this change?

The `geist` package was likely no longer needed in the project, possibly because:
- The project may have switched to a different font or design system
- The functionality provided by `geist` might be handled by another package or native solution
- Removing unused dependencies helps reduce bundle size and simplify dependency management