### PR TITLE
upgraded tailwind

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "react-scan": "^0.3.3",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.1.0",
-        "tailwindcss": "^4.1.1",
+        "tailwindcss": "^4.1.2",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.8.2",
         "zod": "^3.24.2",
@@ -1307,7 +1307,7 @@
 
     "tailwind-merge": ["tailwind-merge@3.1.0", "", {}, "sha512-aV27Oj8B7U/tAOMhJsSGdWqelfmudnGMdXIlMnk1JfsjwSjts6o8HyfN7SFH3EztzH4YH8kk6GbLTHzITJO39Q=="],
 
-    "tailwindcss": ["tailwindcss@4.1.1", "", {}, "sha512-QNbdmeS979Efzim2g/bEvfuh+fTcIdp1y7gA+sb6OYSW74rt7Cr7M78AKdf6HqWT3d5AiTb7SwTT3sLQxr4/qw=="],
+    "tailwindcss": ["tailwindcss@4.1.2", "", {}, "sha512-VCsK+fitIbQF7JlxXaibFhxrPq4E2hDcG8apzHUdWFMCQWD8uLdlHg4iSkZ53cgLCCcZ+FZK7vG8VjvLcnBgKw=="],
 
     "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
 
@@ -1404,6 +1404,10 @@
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "@tailwindcss/node/tailwindcss": ["tailwindcss@4.1.1", "", {}, "sha512-QNbdmeS979Efzim2g/bEvfuh+fTcIdp1y7gA+sb6OYSW74rt7Cr7M78AKdf6HqWT3d5AiTb7SwTT3sLQxr4/qw=="],
+
+    "@tailwindcss/postcss/tailwindcss": ["tailwindcss@4.1.1", "", {}, "sha512-QNbdmeS979Efzim2g/bEvfuh+fTcIdp1y7gA+sb6OYSW74rt7Cr7M78AKdf6HqWT3d5AiTb7SwTT3sLQxr4/qw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-scan": "^0.3.3",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.1.0",
-    "tailwindcss": "^4.1.1",
+    "tailwindcss": "^4.1.2",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.8.2",
     "zod": "^3.24.2"


### PR DESCRIPTION
### TL;DR

Upgraded TailwindCSS from version 4.1.1 to 4.1.2.

### What changed?

This PR updates the TailwindCSS dependency from version 4.1.1 to 4.1.2 in both `package.json` and `bun.lock` files. The lock file also includes some additional references to the TailwindCSS package in the `@tailwindcss/node/tailwindcss` and `@tailwindcss/postcss/tailwindcss` sections.

### Why make this change?

Keeping dependencies up-to-date ensures we have the latest bug fixes and improvements. TailwindCSS 4.1.2 likely contains minor bug fixes and performance improvements over the previous version.