### PR TITLE
fixed runtime warning and eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,14 +8,9 @@ import prettierPlugin from "eslint-plugin-prettier";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import unicornPlugin from "eslint-plugin-unicorn";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
@@ -28,7 +23,7 @@ const eslintConfig = [
     "plugin:prettier/recommended",
   ),
   {
-    ignores: ["**/.next/**", "**/node_modules/**", "**/dist/**", "**/build/**"],
+    ignores: [".next", "node_modules", ".vercel"],
   },
   {
     plugins: {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const alt = "StorySync - Create, Share, Inspire";
 export const size = {
   width: 1200,

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const alt = "StorySync - Create, Share, Inspire";
 export const size = {
   width: 1200,


### PR DESCRIPTION
### TL;DR

Updated runtime configuration for OpenGraph images and simplified ESLint configuration.

### What changed?

- Changed the runtime for OpenGraph and Twitter images from `edge` to `nodejs`
- Modernized ESLint configuration by:
  - Replacing manual `__dirname` calculation with the native `import.meta.dirname`
  - Simplified ignored paths in ESLint config to use shorter directory names
  - Removed unnecessary imports (`path` and `fileURLToPath`)

### Why make this change?

The switch from `edge` to `nodejs` runtime for image generation provides better compatibility with the application's deployment environment. The ESLint configuration updates take advantage of modern ESM features and simplify maintenance by using more concise directory references.