### PR TITLE
fixed auto refresh issue

### DIFF
--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -20,7 +20,6 @@ const handleLogout = async () => {
     deleteCookie("access"),
     deleteCookie("refresh"),
   ]);
-  window.location.href = "/";
 };
 
 export const checkAndRefreshToken = async () => {


### PR DESCRIPTION
### TL;DR

Removed automatic page redirection after logout

### What changed?

Removed the line `window.location.href = "/"` from the `handleLogout` function in the `useTokenRefresh.ts` file. This change prevents automatic redirection to the home page after a user logs out.

### Why make this change?

This change gives more control over post-logout navigation flow. Instead of forcing redirection to the home page, the application can now handle post-logout navigation in a more flexible way, potentially allowing for custom logout experiences or redirects based on specific conditions.