### PR TITLE
removed unnecessary classnames

### DIFF
--- a/src/components/ProfileInfo.tsx
+++ b/src/components/ProfileInfo.tsx
@@ -367,7 +367,7 @@ export default function ProfileInfo() {
                   control={form.control}
                   name="password"
                   render={({ field }) => (
-                    <FormItem className="space-y-2">
+                    <FormItem>
                       <FormLabel>Password</FormLabel>
                       <FormControl>
                         <Input
@@ -385,7 +385,7 @@ export default function ProfileInfo() {
                   control={form.control}
                   name="confirmPassword"
                   render={({ field }) => (
-                    <FormItem className="space-y-2">
+                    <FormItem>
                       <FormLabel>Confirm Password</FormLabel>
                       <FormControl>
                         <Input


### PR DESCRIPTION
### TL;DR

Removed unnecessary spacing in password form fields.

### What changed?

Removed the `className="space-y-2"` property from two `FormItem` components in the ProfileInfo component:
- Removed from the password field's FormItem
- Removed from the confirmPassword field's FormItem

### Why make this change?

The `space-y-2` class was adding unnecessary vertical spacing between elements in the password form fields. Removing it creates a more consistent appearance with the rest of the form elements and improves the overall visual design.