### PR TITLE
dependencies chck weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
### TL;DR

Changed Dependabot update frequency from daily to weekly.

### What changed?

Modified `.github/dependabot.yml` to change the update interval for the Bun package ecosystem from `daily` to `weekly`.

### Why make this change?

Reducing the frequency of Dependabot updates helps decrease notification noise and PR volume while still ensuring dependencies are kept reasonably up-to-date. Weekly updates provide a better balance between staying current and managing the overhead of dependency maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dependabot configuration to check for "bun" package updates weekly instead of daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->